### PR TITLE
xcode12対応

### DIFF
--- a/Sources/BaseButtonBarPagerTabStripViewController.swift
+++ b/Sources/BaseButtonBarPagerTabStripViewController.swift
@@ -101,7 +101,6 @@ open class BaseButtonBarPagerTabStripViewController<ButtonBarCellType: UICollect
 
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        buttonBarView.layoutIfNeeded()
         isViewAppearing = true
     }
 


### PR DESCRIPTION
xcode12でビルドするとナビゲーションバー折りたたみ＋スクローラブルタブ両方を実装している画面で、折りたたみがカクつく問題を修正